### PR TITLE
fix bug in rel dpen_data_0th_order

### DIFF
--- a/remind_mfa/common/fit_stocks.py
+++ b/remind_mfa/common/fit_stocks.py
@@ -192,7 +192,7 @@ class StockFitter(RemindMFABaseModel):
         target = self.last_hist(historic)
         diff = fit - target
         if relative:
-            diff /= max(target, 1e-2) ** 2
+            diff /= max(target, 1e-6) ** 2
             prefix = "rel_"
         else:
             prefix = ""


### PR DESCRIPTION
fix bug in rel dpen_data_0th_order preventing plastic model stock fitting without time factor: align dpen_data_0th_order epsilon with pen_data_0th_order